### PR TITLE
管理者ページの作成

### DIFF
--- a/src/Components/AdminPageComponent.tsx
+++ b/src/Components/AdminPageComponent.tsx
@@ -1,0 +1,47 @@
+import { LockPerson, People, School } from '@mui/icons-material';
+import { Container } from "@mui/material";
+import { Stack } from "@mui/system";
+import { ReactNode } from 'react';
+import AdminCard from "./parts/AdminCard";
+
+
+const ADMIN_PAGES = [
+    {
+        title: <CardTitle title={"学生管理ページ"} icon={<People />} />,
+        description: "学生情報を閲覧・編集・削除します。",
+        href: "/Admin/Students"
+    },
+    {
+        title: <CardTitle title={"教員管理ページ"} icon={<LockPerson />} />,
+        description: "教員情報を閲覧・編集・削除します。",
+        href: "/Admin/Teachers"
+    },
+    {
+        title: <CardTitle title={"学校情報ページ"} icon={<School />} />,
+        description: "学校情報を閲覧・編集します。",
+        href: "/Admin/School"
+    }
+]
+
+async function CardTitle({ title, icon }: { title: string, icon: ReactNode }) {
+    return (
+        <Stack spacing={1} direction={"row"} alignItems={"center"} justifyItems={"center"}>
+            {icon}
+            <div>
+                {title}
+            </div>
+        </Stack>
+    )
+}
+
+export default async function AdminPageComponent() {
+    return (
+        <Container>
+            <Stack sx={{ m: 5 }} spacing={2} direction="row">
+                {ADMIN_PAGES.map((page) => {
+                    return <AdminCard {...page} />
+                })}
+            </Stack>
+        </Container>
+    )
+}

--- a/src/Components/AdminPageComponent.tsx
+++ b/src/Components/AdminPageComponent.tsx
@@ -37,7 +37,7 @@ async function CardTitle({ title, icon }: { title: string, icon: ReactNode }) {
 export default async function AdminPageComponent() {
     return (
         <Container>
-            <Stack sx={{ m: 5 }} spacing={2} direction="row">
+            <Stack sx={{ m: 5 }} spacing={2} direction={{ xs: "column", lg: "row" }}>
                 {ADMIN_PAGES.map((page) => {
                     return <AdminCard {...page} />
                 })}

--- a/src/Components/parts/AdminCard.tsx
+++ b/src/Components/parts/AdminCard.tsx
@@ -1,0 +1,20 @@
+import { Card, CardActionArea, CardContent, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+export default async function AdminCard({ title, description, href }: { title: ReactNode, description: ReactNode, href: string }) {
+    return (
+        <Card>
+            <CardActionArea LinkComponent={"a"} href={href}>
+                <CardContent>
+                    <Typography gutterBottom variant="h5" component="div">
+                        {title}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                        {description}
+                    </Typography>
+                </CardContent>
+            </CardActionArea>
+        </Card>
+    )
+
+}

--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -1,0 +1,13 @@
+import AdminPageComponent from "@/Components/AdminPageComponent";
+import { Container } from "@mui/material";
+import { Box } from "@mui/system";
+
+export default async function AdminPage() {
+    return (
+        <Container>
+            <Box sx={{ m: 5 }}>
+                <AdminPageComponent />
+            </Box>
+        </Container>
+    )
+}


### PR DESCRIPTION
## 概要

管理者のみが閲覧できる管理ページ

## 変更点

以下のページに移動できる、管理者ページのポータルのようなページを作成しました。

- 学生管理ページ
- 教員管理ページ
- 学校情報ページ

現在は空のページにリンクします。
縦並びに、十分な横幅があれば各カードを横並びで表示します。

## 関連Issue

- closes #25 
