### PR TITLE
ボタンの重複とチャットのローディングを追加

### DIFF
--- a/src/Components/parts/Chat/Chat.tsx
+++ b/src/Components/parts/Chat/Chat.tsx
@@ -16,6 +16,7 @@ import {
   Paper,
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
+import CircularProgress from '@mui/material/CircularProgress';
 
 interface Message {
   id: string;
@@ -29,11 +30,13 @@ const API_LINK = process.env.NEXT_PUBLIC_BACKEND_DEV_URL;
 export const ChatComponent: React.FC = () => {
   const { user } = useSelector((state: RootState) => state.auth);
   const [message, setMessage] = useState<string>('');
+  const [loading,setLoading]=useState<boolean>(false);
   const router = useRouter();
 
   const sendMessage = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!message.trim() || !user) return;
+    setLoading(true);
     try {
       const token = Cookies.get('access_token');
       if (!token) {
@@ -73,6 +76,7 @@ export const ChatComponent: React.FC = () => {
       console.error(err);
     } finally {
       setMessage('');
+      setLoading(false);
     }
   };
 
@@ -91,6 +95,7 @@ export const ChatComponent: React.FC = () => {
         <IconButton aria-label="Send" type="submit">
           <SendIcon />
         </IconButton>
+        {loading && <CircularProgress size={24} sx={{ ml: 2 }} />}
       </Box>
     </Container>
   );

--- a/src/Components/parts/Chat/DynamincChat.tsx
+++ b/src/Components/parts/Chat/DynamincChat.tsx
@@ -16,6 +16,8 @@ import {
   Toolbar
 } from '@mui/material';
 import SendIcon from '@mui/icons-material/Send';
+import CircularProgress from '@mui/material/CircularProgress';
+
 
 interface Message {
   id: string;
@@ -30,6 +32,7 @@ export const DynamicChatComponent: React.FC = () => {
   const [message, setMessage] = useState<string>('');
   const [messages, setMessages] = useState<Message[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading,setLoading]=useState<boolean>(false);
   const router = useRouter();
   const { session_id } = useParams();
   const token = Cookies.get('access_token');
@@ -114,6 +117,7 @@ export const DynamicChatComponent: React.FC = () => {
     };
 
     setMessages([...messages, optimisticMessage]);
+    setLoading(true);
 
     try {
       const res = await fetch(`${API_LINK}/api/input/chat/`, {
@@ -147,6 +151,7 @@ export const DynamicChatComponent: React.FC = () => {
       setError('Failed to send message');
     } finally {
       setMessage('');
+      setLoading(false);
     }
   };
 
@@ -228,6 +233,7 @@ export const DynamicChatComponent: React.FC = () => {
         <IconButton aria-label="Send" size="large" className="send-button" type="submit" sx={{ color: '#1E3C5F' }}>
           <SendIcon fontSize="inherit" />
         </IconButton>
+        {loading && <CircularProgress size={24} sx={{ ml: 2 }} />}
       </Box>
     </Container>
   );

--- a/src/Components/parts/ChatAppbar.tsx
+++ b/src/Components/parts/ChatAppbar.tsx
@@ -56,16 +56,7 @@ export const ChatAppbar: React.FC<ChatAppbarProps> = ({
       padding: 0,
     }}>
       {/* 開閉ボタン */}
-      <IconButton
-        edge="start"
-        aria-label="menu"
-        onClick={handleDrawerToggle}
-        sx={{
-          display: { sm: pcOpen ? "none" : "block" }, // PC画面でDrawerが開いている時は非表示
-        }}
-      >
         <AlignHorizontalLeftIcon />
-      </IconButton>
       {/* タイトル */}
       <Typography 
         variant="h6"


### PR DESCRIPTION
## 概要

- navbatを閉じた際にハンバーガーメニューが重複していたので修正
- チャット送信時に応答が車でローディングアイコンを表示するように修正

## 変更点

- ChatAppbar.tsxで表示していたハンバーガーメニューを削除
- Chat.tsxでチャット送信時にローディングを表示するように変更
- DynamicChat.tsxでチャット送信時にローディングを表示するように変更

## 関連Issue

- 関連Issue: #32 
